### PR TITLE
Fix footer link

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -6,7 +6,7 @@ const Footer = () => {
       <p>
         Built by{' '}
         <a
-          href="https://shashiirk.github.io/portfolio"
+          href="https://shashi.vercel.app/"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
Currently, the link in the footer links to your old portofolio, which isn't hosted on Github Pages anymore. This fixes that by instead linking to your new portofolio. 